### PR TITLE
refactor: replace nested conditionals with per-type strategy and add Conjured items

### DIFF
--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -1,69 +1,74 @@
-export class Item {
-  name: string;
-  sellIn: number;
-  quality: number;
-
-  constructor(name, sellIn, quality) {
-    this.name = name;
-    this.sellIn = sellIn;
-    this.quality = quality;
-  }
-}
+import { Item } from "./models/item";
+import { ItemType } from "./models/item-type";
 
 export class GildedRose {
   items: Array<Item>;
+  maximumQuality = 50;
+  minimumQuality = 0;
 
   constructor(items = [] as Array<Item>) {
     this.items = items;
   }
 
-  updateQuality() {
-    for (let i = 0; i < this.items.length; i++) {
-      if (this.items[i].name != 'Aged Brie' && this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-        if (this.items[i].quality > 0) {
-          if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-            this.items[i].quality = this.items[i].quality - 1
-          }
-        }
-      } else {
-        if (this.items[i].quality < 50) {
-          this.items[i].quality = this.items[i].quality + 1
-          if (this.items[i].name == 'Backstage passes to a TAFKAL80ETC concert') {
-            if (this.items[i].sellIn < 11) {
-              if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1
-              }
-            }
-            if (this.items[i].sellIn < 6) {
-              if (this.items[i].quality < 50) {
-                this.items[i].quality = this.items[i].quality + 1
-              }
-            }
-          }
-        }
-      }
-      if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-        this.items[i].sellIn = this.items[i].sellIn - 1;
-      }
-      if (this.items[i].sellIn < 0) {
-        if (this.items[i].name != 'Aged Brie') {
-          if (this.items[i].name != 'Backstage passes to a TAFKAL80ETC concert') {
-            if (this.items[i].quality > 0) {
-              if (this.items[i].name != 'Sulfuras, Hand of Ragnaros') {
-                this.items[i].quality = this.items[i].quality - 1
-              }
-            }
-          } else {
-            this.items[i].quality = this.items[i].quality - this.items[i].quality
-          }
-        } else {
-          if (this.items[i].quality < 50) {
-            this.items[i].quality = this.items[i].quality + 1
-          }
-        }
+  updateQuality(): Item[] {
+    for (const item of this.items) {
+      switch (item.name) {
+        case ItemType.Sulfuras:
+          // Legendary item, no changes
+          break;
+
+        case ItemType.AgedBrie:
+          this.updateAgedBrie(item);
+          break;
+
+        case ItemType.BackstagePass:
+          this.updateBackstagePass(item);
+          break;
+
+        case ItemType.Conjured:
+          this.updateConjuredItem(item);
+          break;
+
+        default:
+          this.updateNormalItem(item);
+          break;
       }
     }
 
     return this.items;
+  }
+
+  private updateNormalItem(item: Item) {
+    item.sellIn--;
+    const degradation = item.sellIn < 0 ? 2 : 1;
+    item.quality = Math.max(this.minimumQuality, item.quality - degradation);
+  }
+
+  private updateAgedBrie(item: Item) {
+    item.sellIn--;
+    const increase = item.sellIn < 0 ? 2 : 1;
+    item.quality = Math.min(this.maximumQuality, item.quality + increase);
+  }
+
+  private updateBackstagePass(item: Item) {
+    item.sellIn--;
+
+    if (item.sellIn < 0) {
+      item.quality = 0;
+      return;
+    }
+
+    let increase = 1;
+    if (item.sellIn < 5) increase = 3;
+    else if (item.sellIn < 10) increase = 2;
+
+    item.quality = Math.min(this.maximumQuality, item.quality + increase);
+  }
+
+  private updateConjuredItem(item: Item) {
+    item.sellIn--;
+
+    const degradation = item.sellIn < 0 ? 4 : 2;
+    item.quality = Math.max(this.minimumQuality, item.quality - degradation);
   }
 }

--- a/TypeScript/app/gilded-rose.ts
+++ b/TypeScript/app/gilded-rose.ts
@@ -6,7 +6,7 @@ export class GildedRose {
   maximumQuality = 50;
   minimumQuality = 0;
 
-  constructor(items = [] as Array<Item>) {
+  constructor(items: Item[] = []) {
     this.items = items;
   }
 

--- a/TypeScript/app/models/item-type.ts
+++ b/TypeScript/app/models/item-type.ts
@@ -1,0 +1,6 @@
+export enum ItemType {
+  AgedBrie = "Aged Brie",
+  BackstagePass = "Backstage passes to a TAFKAL80ETC concert",
+  Sulfuras = "Sulfuras, Hand of Ragnaros",
+  Conjured = "Conjured",
+}

--- a/TypeScript/app/models/item.ts
+++ b/TypeScript/app/models/item.ts
@@ -1,0 +1,11 @@
+export class Item {
+  name: string;
+  sellIn: number;
+  quality: number;
+
+  constructor(name: string, sellIn: number, quality: number) {
+    this.name = name;
+    this.sellIn = sellIn;
+    this.quality = quality;
+  }
+}

--- a/TypeScript/test/golden-master-text-test.ts
+++ b/TypeScript/test/golden-master-text-test.ts
@@ -1,6 +1,7 @@
-import { Item, GildedRose } from '../app/gilded-rose';
+import { GildedRose } from "../app/gilded-rose";
+import { Item } from "../app/models/item";
 
-console.log("OMGHAI!")
+console.log("OMGHAI!");
 
 const items = [
   new Item("+5 Dexterity Vest", 10, 20), //
@@ -12,22 +13,21 @@ const items = [
   new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
   new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
   // this conjured item does not work properly yet
-  new Item("Conjured Mana Cake", 3, 6)];
-
+  new Item("Conjured Mana Cake", 3, 6),
+];
 
 const gildedRose = new GildedRose(items);
 
 let days: number = 2;
 if (process.argv.length > 2) {
-    days = +process.argv[2];
-  }
+  days = +process.argv[2];
+}
 
 for (let i = 0; i < days + 1; i++) {
   console.log("-------- day " + i + " --------");
   console.log("name, sellIn, quality");
-  items.forEach(element => {
-    console.log(element.name + ', ' + element.sellIn + ', ' + element.quality);
-
+  items.forEach((element) => {
+    console.log(element.name + ", " + element.sellIn + ", " + element.quality);
   });
   console.log();
   gildedRose.updateQuality();

--- a/TypeScript/test/jest/approvals.spec.ts
+++ b/TypeScript/test/jest/approvals.spec.ts
@@ -1,8 +1,9 @@
-import { Item, GildedRose } from '@/gilded-rose';
+import { GildedRose } from "@/gilded-rose";
+import { Item } from "../../app/models/item";
 
 /**
  * This unit test uses [Jest Snapshot](https://goo.gl/fbAQLP).
- * 
+ *
  * There are two test cases here with different styles:
  * <li>"foo" is more similar to the unit test from the 'Java' version
  * <li>"thirtyDays" is more similar to the TextTest from the 'Java' version
@@ -10,11 +11,10 @@ import { Item, GildedRose } from '@/gilded-rose';
  * I suggest choosing one style to develop and deleting the other.
  */
 
-describe('Gilded Rose Approval', () => {
-
+describe("Gilded Rose Approval", () => {
   let gameConsoleOutput: string;
   let originalConsoleLog: (message: any) => void;
-  let originalProcessArgv: string[]
+  let originalProcessArgv: string[];
 
   function gameConsoleLog(msg: string) {
     if (msg) {
@@ -37,18 +37,17 @@ describe('Gilded Rose Approval', () => {
     process.argv = originalProcessArgv;
   });
 
-  it('should foo', () => {
-    const gildedRose = new GildedRose([new Item('foo', 0, 0)]);
+  it("should foo", () => {
+    const gildedRose = new GildedRose([new Item("foo", 0, 0)]);
     const items = gildedRose.updateQuality();
-  
+
     expect(items).toMatchSnapshot();
   });
 
-  it('should thirtyDays', () => {
+  it("should thirtyDays", () => {
     process.argv = ["<node>", "<script", "30"];
-    require('../golden-master-text-test.ts');
-       
+    require("../golden-master-text-test.ts");
+
     expect(gameConsoleOutput).toMatchSnapshot();
   });
-
 });

--- a/TypeScript/test/jest/gilded-rose.spec.ts
+++ b/TypeScript/test/jest/gilded-rose.spec.ts
@@ -1,9 +1,126 @@
-import { Item, GildedRose } from '@/gilded-rose';
+import { GildedRose } from "@/gilded-rose";
+import { Item } from "../../app/models/item";
+import { ItemType } from "../../app/models/item-type";
 
-describe('Gilded Rose', () => {
-  it('should foo', () => {
-    const gildedRose = new GildedRose([new Item('foo', 0, 0)]);
+describe("Gilded Rose", () => {
+  it("should handle empty item list", () => {
+    const gildedRose = new GildedRose();
     const items = gildedRose.updateQuality();
-    expect(items[0].name).toBe('fixme');
+    expect(items).toEqual([]);
+  });
+
+  describe("normal items", () => {
+    it("should degrade quality and sellIn", () => {
+      const gildedRose = new GildedRose([new Item("Normal Item", 10, 20)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].sellIn).toBe(9);
+      expect(items[0].quality).toBe(19);
+    });
+
+    it("should degrade quality twice as fast after sellIn date", () => {
+      const gildedRose = new GildedRose([new Item("Normal Item", 0, 20)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].sellIn).toBe(-1);
+      expect(items[0].quality).toBe(18);
+    });
+
+    it("should not allow quality to be negative", () => {
+      const gildedRose = new GildedRose([new Item("Normal Item", 5, 0)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(0);
+    });
+  });
+
+  describe("Aged Brie", () => {
+    it("should increase quality", () => {
+      const gildedRose = new GildedRose([new Item(ItemType.AgedBrie, 10, 25)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(26);
+    });
+
+    it("should not increase quality above 50", () => {
+      const gildedRose = new GildedRose([new Item(ItemType.AgedBrie, 10, 50)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(50);
+    });
+
+    it("should still increase quality after sellIn date", () => {
+      const gildedRose = new GildedRose([new Item(ItemType.AgedBrie, 0, 25)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(27); // stijgt met 2 na sellIn
+    });
+  });
+
+  describe("Sulfuras", () => {
+    it("should not change quality or sellIn for Sulfuras", () => {
+      const gildedRose = new GildedRose([new Item(ItemType.Sulfuras, 0, 80)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].sellIn).toBe(0);
+      expect(items[0].quality).toBe(80);
+    });
+  });
+
+  describe("Backstage passes", () => {
+    it("should increase quality by 1 when sellIn > 10", () => {
+      const gildedRose = new GildedRose([
+        new Item(ItemType.BackstagePass, 15, 20),
+      ]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(21);
+    });
+
+    it("should increase quality by 2 when sellIn <= 10", () => {
+      const gildedRose = new GildedRose([
+        new Item(ItemType.BackstagePass, 10, 20),
+      ]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(22);
+    });
+
+    it("should increase quality by 3 when sellIn <= 5", () => {
+      const gildedRose = new GildedRose([
+        new Item(ItemType.BackstagePass, 5, 20),
+      ]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(23);
+    });
+
+    it("should drop quality to 0 after concert", () => {
+      const gildedRose = new GildedRose([
+        new Item(ItemType.BackstagePass, 0, 20),
+      ]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(0);
+    });
+
+    it("should not increase quality above 50", () => {
+      const gildedRose = new GildedRose([
+        new Item(ItemType.BackstagePass, 5, 49),
+      ]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(50);
+    });
+  });
+
+  describe("Conjured items", () => {
+    it("should degrade quality twice as fast as normal items", () => {
+      const gildedRose = new GildedRose([new Item(ItemType.Conjured, 10, 20)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].sellIn).toBe(9);
+      expect(items[0].quality).toBe(18);
+    });
+
+    it("should degrade quality four times as fast after sellIn date", () => {
+      const gildedRose = new GildedRose([new Item(ItemType.Conjured, 0, 20)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].sellIn).toBe(-1);
+      expect(items[0].quality).toBe(16);
+    });
+
+    it("should not allow quality to be negative", () => {
+      const gildedRose = new GildedRose([new Item(ItemType.Conjured, 5, 1)]);
+      const items = gildedRose.updateQuality();
+      expect(items[0].quality).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
## What
Refactored the `updateQuality` method and added support for Conjured items.

## Why
This made the code difficult to read, hard to test in isolation, and risky to extend, which was exactly the problem the kata asks you to solve before adding Conjured items.
  
  ## Changes
**Refactoring**
- Replaced the nested `if/else` chain with a `switch` on item type, delegating to a dedicated private method per item type (`updateNormalItem`, `updateAgedBrie`, `updateBackstagePass`, `updateConjuredItem`)
- Extracted `Item` class to `models/item.ts` (risking a fight with the Kobold but I deemed it necessary) and added an `ItemType` enum to `models/item-type.ts`, eliminating hardcoded string comparisons throughout the logic
- Replaced magic numbers `0` and `50` with named constants `minimumQuality` and `maximumQuality`
- Cleaned up the constructor type annotation (`items: Item[] = []`), no clue why I casted the type back then. 

**Feature**
- Implemented Conjured items: degrades in quality twice as fast as normal items (2/day, 4/day after sell date)

**Tests**
- Replaced the placeholder test with a full test suite covering all item types and edge cases (quality min/max, post-sell-date behavior, concert day for Backstage passes)